### PR TITLE
Disable CSS highlighting of search results, so it does not disturb when searching for longer sentences with AI search

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -10,3 +10,16 @@
 span.pre {
   color: #2B2D42;
 }
+
+/* Unterdrückt das gelbe Sphinx-Such-Highlighting auf Artikelseiten */
+span.highlighted {
+    background: transparent !important;
+    background-color: transparent !important;
+    color: inherit !important;
+    font-weight: inherit !important;
+    box-shadow: none !important;
+    border: none !important;
+    outline: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+}


### PR DESCRIPTION
Deployed on http://docs-preview.searchhub.io.s3-website.eu-central-1.amazonaws.com/ for testing